### PR TITLE
updates for zig 0.13.0 and btree.c 0.6.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 zig-out
 zig-cache
+.zig-cache

--- a/build.zig
+++ b/build.zig
@@ -11,7 +11,7 @@ pub fn build(b: *std.Build) void {
 
     const btree_zig = b.addStaticLibrary(.{
         .name = "btree-zig",
-        .root_source_file = .{ .path = "src/btree.zig" },
+        .root_source_file = b.path("src/btree.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -28,7 +28,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const module = b.addModule("btree_c_zig", .{
-        .root_source_file = .{ .path = "src/btree.zig" },
+        .root_source_file = b.path("src/btree.zig"),
     });
 
     // Include header files from btree.c lib
@@ -37,7 +37,7 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(btree_zig);
 
     const btree_zig_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/btree.zig" },
+        .root_source_file = b.path("src/btree.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,10 +2,10 @@
     .name = "btree-zig",
     .version = "0.0.1",
     .dependencies = .{
-    	.btree_c = .{
-	    .url = "https://github.com/tidwall/btree.c/archive/v0.6.1.tar.gz",
-	    .hash = "122032a19f309225db04415bcecfa87c95d3110b1d90d1223a613f3302a2a46e7f6f"
-	}
+        .btree_c = .{
+            .url = "https://github.com/tidwall/btree.c/archive/v0.6.4.tar.gz",
+            .hash = "122013c90518e7c28902e567868889600a769c24d32ea117462325f92c635af1bf34",
+        },
     },
     .paths = .{
         "",


### PR DESCRIPTION
Hello, this pull request is to get this running in zig 0.13.0, primarily just switching out setting the path property for using b.path() with root_source_file.

Also updates btree.c to the latest version.

Build and tests are working.

Thanks!