### PR TITLE
Update to Zig 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ zig fetch --save https://github.com/almmiko/btree.c-zig/archive/<git-ref>.tar.gz
 Or manually
 ```zig
 .{
-    .name = "project-zig",
+    .name = .project_zig,
     .version = "0.0.0",
     .dependencies = .{
-        .@"btree-zig" = .{
+        .btree_zig = .{
             .url = "https://github.com/almmiko/btree.c-zig/archive/<git-ref>.tar.gz",
             .hash = "1220450bb9feb21c29018e21a8af457859eb2a4607a6017748bb618907b4cf18c67b",
         },
@@ -32,15 +32,15 @@ Or manually
 Add dependency in your `build.zig`
 
 ```zig
-const btree_zig = b.dependency("btree-zig", .{
+const btree_zig = b.dependency("btree_zig", .{
     .target = target,
     .optimize = optimize,
 });
 
 const btree_zig_module = btree_zig.module("btree_c_zig");
 
-exe.root_module.addImport("btree-zig", btree_zig_module);
-exe.linkLibrary(btree_zig.artifact("btree-zig"));
+exe.root_module.addImport("btree_zig", btree_zig_module);
+exe.linkLibrary(btree_zig.artifact("btree_zig"));
 ```
 
 ## Usage

--- a/build.zig
+++ b/build.zig
@@ -9,11 +9,14 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    const btree_zig = b.addStaticLibrary(.{
-        .name = "btree-zig",
-        .root_source_file = b.path("src/btree.zig"),
-        .target = target,
-        .optimize = optimize,
+    const btree_zig = b.addLibrary(.{
+        .name = "btree_zig",
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/btree.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     btree_zig.linkLibC();
@@ -37,9 +40,11 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(btree_zig);
 
     const btree_zig_tests = b.addTest(.{
-        .root_source_file = b.path("src/btree.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/btree.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     btree_zig_tests.linkLibrary(btree_zig);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,8 @@
 .{
-    .name = "btree-zig",
+    .name = .btree_zig,
     .version = "0.0.1",
+    .zig_minimum_version = "0.14.0",
+    .fingerprint = 0x637b535726bf11d8,
     .dependencies = .{
         .btree_c = .{
             .url = "https://github.com/tidwall/btree.c/archive/v0.6.4.tar.gz",

--- a/src/btree.zig
+++ b/src/btree.zig
@@ -8,7 +8,7 @@ pub fn Btree(comptime T: type, comptime Context: type) type {
     return struct {
         const Self = @This();
 
-        handle: *c.struct_btree = undefined,
+        handle: *c.struct_btree,
 
         pub fn init(
             max_items: usize,
@@ -212,8 +212,6 @@ test "btree init" {
 
     var btree = Btree(User, void).init(0, cb.compare, null);
     defer btree.deinit();
-
-    try std.testing.expect(btree.handle != undefined);
 }
 
 test "btree set" {


### PR DESCRIPTION
This PR updates the build system to Zig 0.14. The required part was adding a fingerprint and changing the name in `build.zig.zon`, but I also replaced deprecated fields/functions in `build.zig`.

The tests were also failing due to the comparison to `undefined` which is apparently forbidden (see [here](https://ziggit.dev/t/how-to-detect-that-a-pointer-is-undefined/4026/3)). I took the path of least resistance and simply removed the test. I think that if the `handle` can be `undefined` then it would be more idiomatic to make it an optional (but it would probably unnecessarily complicate the rest of `Btree`).

Please let me know if there are any further modifications you’d like.